### PR TITLE
use a valid way to log

### DIFF
--- a/custom_components/dwd_weather/connector.py
+++ b/custom_components/dwd_weather/connector.py
@@ -56,7 +56,7 @@ class DWDWeatherData:
         if self.dwd_weather.get_station_name(False) == "":
             _LOGGER.exception("No update possible")
         else:
-            _LOGGER.info("Updating ", self.dwd_weather.get_station_name(False))
+            _LOGGER.info("Updating {}".format(self.dwd_weather.get_station_name(False)))
             self.infos[ATTR_LATEST_UPDATE] = datetime.now(timezone.utc)
             self.latest_update = datetime.now(timezone.utc)
             self.infos[ATTR_ISSUE_TIME] = self.dwd_weather.issue_time


### PR DESCRIPTION
am i the only one which gets spammed by this? :D

fixed the log call to a valid one, see https://docs.python.org/3/library/logging.html#logging.Logger.debug for more info about  args* and how they get handled

```
Oct 05 20:55:49 hass[20607]: --- Logging error ---
Oct 05 20:55:49 hass[20607]: Traceback (most recent call last):
Oct 05 20:55:49 hass[20607]:   File "/root/.pyenv/versions/3.8.5/lib/python3.8/logging/__init__.py", line 1081, in emit
Oct 05 20:55:49 hass[20607]:     msg = self.format(record)
Oct 05 20:55:49 hass[20607]:   File "/root/.pyenv/versions/3.8.5/lib/python3.8/logging/__init__.py", line 925, in format
Oct 05 20:55:49 hass[20607]:     return fmt.format(record)
Oct 05 20:55:49 hass[20607]:   File "/root/.pyenv/versions/3.8.5/lib/python3.8/logging/__init__.py", line 664, in format
Oct 05 20:55:49 hass[20607]:     record.message = record.getMessage()
Oct 05 20:55:49 hass[20607]:   File "/root/.pyenv/versions/3.8.5/lib/python3.8/logging/__init__.py", line 369, in getMessage
Oct 05 20:55:49 hass[20607]:     msg = msg % self.args
Oct 05 20:55:49 hass[20607]: TypeError: not all arguments converted during string formatting
Oct 05 20:55:49 hass[20607]: Call stack:
Oct 05 20:55:49 hass[20607]:   File "/root/.pyenv/versions/3.8.5/lib/python3.8/threading.py", line 890, in _bootstrap
Oct 05 20:55:49 hass[20607]:     self._bootstrap_inner()
Oct 05 20:55:49 hass[20607]:   File "/root/.pyenv/versions/3.8.5/lib/python3.8/threading.py", line 932, in _bootstrap_inner
Oct 05 20:55:49 hass[20607]:     self.run()
Oct 05 20:55:49 hass[20607]:   File "/root/.pyenv/versions/3.8.5/lib/python3.8/threading.py", line 870, in run
Oct 05 20:55:49 hass[20607]:     self._target(*self._args, **self._kwargs)
Oct 05 20:55:49 hass[20607]: Message: 'Updating '
Oct 05 20:55:49 hass[20607]: Arguments: ('STUTTGART-ECHT.',)
```