### PR TITLE
Fix device_state_attributes warnings in HA 2021.12

### DIFF
--- a/custom_components/dwd_weather/sensor.py
+++ b/custom_components/dwd_weather/sensor.py
@@ -225,7 +225,7 @@ class DWDWeatherForecastSensor(Entity):
         return SENSOR_TYPES[self._type][1]
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the state attributes of the device."""
         attributes = {}
 

--- a/custom_components/dwd_weather/weather.py
+++ b/custom_components/dwd_weather/weather.py
@@ -108,6 +108,6 @@ class DWDWeather(WeatherEntity):
         return self._connector.forecast
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return data validity infos."""
         return self._connector.infos


### PR DESCRIPTION
As stated in HA core PR [#47304](https://github.com/home-assistant/core/pull/47304) device_state_attributes is now extra_state_attributes. 
I renamed the function and tested it. It still works as before and fixes the warnings. Should also close #39 