### PR TITLE
Escape backslashes in regular expression

### DIFF
--- a/custom_components/dwd_weather/sensor.py
+++ b/custom_components/dwd_weather/sensor.py
@@ -297,7 +297,7 @@ class DWDWeatherForecastSensor(DWDWeatherEntity, SensorEntity):
         elif self._type == "weather_report":
             result = (
                 re.search(
-                    "\w+, \d{2}\.\d{2}\.\d{2}, \d{2}:\d{2}",
+                    r"\w+, \d{2}\.\d{2}\.\d{2}, \d{2}:\d{2}",
                     self._connector.get_weather_report(),
                 ).group()
                 if self._connector.get_weather_report() is not None


### PR DESCRIPTION
Backslashes must be escaped in regular expressions.

Edit: Prefixing the string seems to be the better solution.

Fixes #119 

This generates a `SyntaxWarning` since Python 3.12.
See https://docs.python.org/3.12/library/re.html