### PR TITLE
Remove use of deprecated HomeAssistantType

### DIFF
--- a/custom_components/dwd_weather/camera.py
+++ b/custom_components/dwd_weather/camera.py
@@ -1,7 +1,8 @@
 import logging
 from custom_components.dwd_weather.connector import DWDMapData
 from homeassistant.components.camera import Camera
-from homeassistant.helpers.typing import ConfigType, HomeAssistantType
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.device_registry import DeviceEntryType
 
@@ -23,7 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
-    hass: HomeAssistantType, entry: ConfigType, async_add_entities
+    hass: HomeAssistant, entry: ConfigType, async_add_entities
 ) -> None:
     """Set up the DWD weather camera platform."""
     hass_data = hass.data[DOMAIN][entry.entry_id]

--- a/custom_components/dwd_weather/sensor.py
+++ b/custom_components/dwd_weather/sensor.py
@@ -22,8 +22,9 @@ from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
 )
+from homeassistant.core import HomeAssistant
 
-from homeassistant.helpers.typing import ConfigType, HomeAssistantType
+from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     ATTR_REPORT_ISSUE_TIME,
@@ -227,7 +228,7 @@ SENSOR_TYPES = {
 
 
 async def async_setup_entry(
-    hass: HomeAssistantType, entry: ConfigType, async_add_entities
+    hass: HomeAssistant, entry: ConfigType, async_add_entities
 ) -> None:
     """Set up the DWD weather sensor platform."""
     hass_data = hass.data[DOMAIN][entry.entry_id]

--- a/custom_components/dwd_weather/weather.py
+++ b/custom_components/dwd_weather/weather.py
@@ -15,8 +15,8 @@ from homeassistant.const import (
     UnitOfSpeed,
     UnitOfTemperature,
 )
-
-from homeassistant.helpers.typing import ConfigType, HomeAssistantType
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     ATTRIBUTION,
@@ -31,7 +31,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
-    hass: HomeAssistantType, entry: ConfigType, async_add_entities
+    hass: HomeAssistant, entry: ConfigType, async_add_entities
 ) -> None:
     """Add a weather entity from a config_entry."""
     hass_data = hass.data[DOMAIN][entry.entry_id]


### PR DESCRIPTION
Remove use of deprecated `HomeAssistantType`. This produces log warnings since HA 2024.5.0.

Fixes #125 