### PR TITLE
Forwarding setup to config entry platforms

### DIFF
--- a/custom_components/dwd_weather/__init__.py
+++ b/custom_components/dwd_weather/__init__.py
@@ -101,7 +101,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             DWDWEATHER_COORDINATOR: dwdweather_coordinator,
         }
 
-        await hass.config_entries.async_forward_entry_setups(entry, "camera")
+        await hass.config_entries.async_forward_entry_setups(entry, ["camera"])
 
     return True
 

--- a/custom_components/dwd_weather/__init__.py
+++ b/custom_components/dwd_weather/__init__.py
@@ -81,9 +81,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
         # Setup weather and sensor platforms
         for component in PLATFORMS:
-            hass.async_create_task(
-                hass.config_entries.async_forward_entry_setup(entry, component)
-            )
+            await hass.config_entries.async_forward_entry_setups(entry, [component])
+
     elif entry.data[CONF_ENTITY_TYPE] == CONF_ENTITY_TYPE_MAP:
         dwd_weather_data = DWDMapData(hass, entry)
 
@@ -102,9 +101,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             DWDWEATHER_COORDINATOR: dwdweather_coordinator,
         }
 
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, "camera")
-        )
+        await hass.config_entries.async_forward_entry_setups(entry, "camera")
 
     return True
 


### PR DESCRIPTION
> Calling hass.config_entries.async_forward_entry_setup is deprecated and will be removed in Home Assistant 2025.6. Instead, await hass.config_entries.async_forward_entry_setups as it can load multiple platforms at once and is more efficient since it does not require a separate import executor job for each platform.

https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/

closes #131 