### PR TITLE
Change precision of daily temperature data to 0

### DIFF
--- a/custom_components/dwd_weather/connector.py
+++ b/custom_components/dwd_weather/connector.py
@@ -497,10 +497,10 @@ class DWDWeatherData:
                     ATTR_FORECAST_PRESSURE: round(pressure / 100, 1)
                     if pressure is not None
                     else None,
-                    ATTR_FORECAST_NATIVE_TEMP: round(temp_max - 273.1, 1)
+                    ATTR_FORECAST_NATIVE_TEMP: round(temp_max - 273.1, 0)
                     if temp_max is not None
                     else None,
-                    ATTR_FORECAST_NATIVE_TEMP_LOW: round(temp_min - 273.1, 1)
+                    ATTR_FORECAST_NATIVE_TEMP_LOW: round(temp_min - 273.1, 0)
                     if temp_min is not None
                     else None,
                     ATTR_WEATHER_UV_INDEX: uv_index,


### PR DESCRIPTION
In 6d96bec85c8536aebd26d489abb9ef15d7e26069 the number of decimal places for temperature was increased from 0 to 1. While this might be useful for the hourly forecast, I wonder if it adds relevant value to the daily forecast. 

I want to suggest to lower the precision to 0 again for the daily forecast in order to keep weekly temperature forecast dashboards as easy to read as possible.