### PR TITLE
Update simple_dwd_weatherforecast to 3.2.2 for HA 2026.3 compatibility

### DIFF
--- a/custom_components/dwd_weather/manifest.json
+++ b/custom_components/dwd_weather/manifest.json
@@ -10,7 +10,7 @@
     "@FL550"
   ],
   "requirements": [
-    "simple_dwd_weatherforecast==3.1.7",
+    "simple_dwd_weatherforecast==3.2.2",
     "markdownify==0.6.5",
     "suntimes==1.1.2"
   ],


### PR DESCRIPTION
Bump simple_dwd_weatherforecast from 3.1.7 to 3.2.2 to address dependency installation failures on Home Assistant 2026.3.0b0 (Python 3.14). The previous version's transitive dependency stream-inflate==0.0.41 lacks pre-built wheels for Python 3.14, causing build failures on HAOS (musl/Alpine).

Fixes #239

https://claude.ai/code/session_01Xnyon3dRqDD6qUuyFpyWZA