### PR TITLE
strip "pre" tag from weather reports

### DIFF
--- a/custom_components/dwd_weather/connector.py
+++ b/custom_components/dwd_weather/connector.py
@@ -274,7 +274,7 @@ class DWDWeatherData:
 
         weather_report_text = self.dwd_weather.get_weather_report(shouldUpdate=False)
         report_text = (
-            markdownify(weather_report_text, strip=["br"])
+            markdownify(weather_report_text, strip=["pre","br"])
             if weather_report_text is not None
             else None
         )


### PR DESCRIPTION
Add "pre" to the list of stripped tags for the weather report when converting to markdown.  Makes the output much more readable in HA.